### PR TITLE
Prepare for podman 5.2 release: stop v5.1 and start v5.3 tagging

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -158,12 +158,12 @@ release_task:
     test -z "$FETCH1" || $PCURL_RETRY -LO "$FETCH1"
     test -z "$FETCH2" || $PCURL_RETRY -LO "$FETCH2"
 
-    # temporary 5.1, 5.2 clone until divergance occurs
+    # temporary 5.2, 5.3 clone until divergance occurs
     for arch in amd64 arm64; do
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.1-rootfs-$arch.tar.zst
       cp $VER_PFX-rootfs-$arch.tar.zst 5.2-rootfs-$arch.tar.zst
-      cp $VER_PFX-latest-$arch 5.1-latest-$arch
+      cp $VER_PFX-rootfs-$arch.tar.zst 5.3-rootfs-$arch.tar.zst
       cp $VER_PFX-latest-$arch 5.2-latest-$arch
+      cp $VER_PFX-latest-$arch 5.3-latest-$arch
     done
     
     STAMP=`date -u '+%Y%m%d%H%M%S'`


### PR DESCRIPTION
Preparing for podman 5.2 release:
- Stop tagging v5.1 images
- Continue tagging v5.2 images
- Start tagging v5.3 images
