### PR TITLE
Push the v5.4 tag of the image to quay

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -122,7 +122,8 @@ release_task:
     IMAGE_REGISTRY: "quay.io"
     IMAGE_REPO: "podman"
     IMAGE_NAME: "machine-os-wsl"
-    IMAGE_TAG: "5.3"
+    IMAGE_TAG_LATEST: "5.3"
+    IMAGE_TAG_NEXT: "5.4"
   depends_on:
     - build
   ec2_instance:
@@ -184,7 +185,8 @@ release_task:
     gh release edit $NEXT_RELEASE --draft=false
 
     # Package the WSL zst compressed disks as an OCI artifact
-    FULL_IMAGE_NAME=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG
+    FULL_IMAGE_NAME=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG_LATEST
+    FULL_IMAGE_NAME_NEXT=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG_NEXT
     buildah manifest create $FULL_IMAGE_NAME
     for disk_arch in x86_64 aarch64; do
       if [ $disk_arch  == "x86_64" ]; then
@@ -201,3 +203,5 @@ release_task:
     # Push the OCI artifact to quay.io
     podman login -u="$QUAY_PODMAN_USERNAME" -p="$QUAY_PODMAN_PASSWORD" quay.io
     podman push $FULL_IMAGE_NAME
+    podman tag $FULL_IMAGE_NAME $FULL_IMAGE_NAME_NEXT
+    podman push $FULL_IMAGE_NAME_NEXT

--- a/README.md
+++ b/README.md
@@ -46,25 +46,11 @@ That means that every GitHub release needs to include WSL disk images for old an
 
 ## When a new version of Podman is released
 
-When there is a new version of Podman, a new version of the Disk Image should be included in the releases:
+After a new version of Podman has been released (i.e. when the fedora package has been updated), the OCI artifact tags should be updated using development Podman version:
 
 ```diff
--    # temporary 5.1, 5.2, 5.3 clone until divergance occurs
-+    # temporary 5.1, 5.2, 5.3, 5.4 clone until divergance occurs
-    for arch in amd64 arm64; do
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.1-rootfs-$arch.tar.zst
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.2-rootfs-$arch.tar.zst
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.3-rootfs-$arch.tar.zst
-+     cp $VER_PFX-rootfs-$arch.tar.zst 5.4-rootfs-$arch.tar.zst
-      cp $VER_PFX-latest-$arch 5.1-latest-$arch
-      cp $VER_PFX-latest-$arch 5.2-latest-$arch
-      cp $VER_PFX-latest-$arch 5.3-latest-$arch
-+     cp $VER_PFX-latest-$arch 5.4-latest-$arch
-```
-
-And the OCI artifact tag should be updated using development Podman version:
-
-```diff
--    IMAGE_TAG: "5.3"
-+    IMAGE_TAG: "5.4"
+-    IMAGE_TAG_LATEST: "5.3"
+-    IMAGE_TAG_NEXT: "5.4"
++    IMAGE_TAG_LATEST: "5.4"
++    IMAGE_TAG_NEXT: "5.5"
 ```


### PR DESCRIPTION
Push a new tag v5.4, so that podman-client in main branch can start using it as the default tag. Continue pushing tag v5.3 too because the GA version of 5.3 hasn't been released yet.

When Podman v5.3 is in Fedora we should stop pushing tag v5.3 of the image and start pushing v5.5 along with v5.4.