### PR TITLE
Start pushing quay.io/podman/machine-os-wsl:5.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,6 +124,7 @@ release_task:
     IMAGE_NAME: "machine-os-wsl"
     IMAGE_TAG_LATEST: "5.3"
     IMAGE_TAG_NEXT: "5.4"
+    IMAGE_TAG_DEV: "5.5"
   depends_on:
     - build
   ec2_instance:
@@ -187,6 +188,7 @@ release_task:
     # Package the WSL zst compressed disks as an OCI artifact
     FULL_IMAGE_NAME=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG_LATEST
     FULL_IMAGE_NAME_NEXT=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG_NEXT
+    FULL_IMAGE_NAME_DEV=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG_DEV
     buildah manifest create $FULL_IMAGE_NAME
     for disk_arch in x86_64 aarch64; do
       if [ $disk_arch  == "x86_64" ]; then
@@ -205,3 +207,5 @@ release_task:
     podman push $FULL_IMAGE_NAME
     podman tag $FULL_IMAGE_NAME $FULL_IMAGE_NAME_NEXT
     podman push $FULL_IMAGE_NAME_NEXT
+    podman tag $FULL_IMAGE_NAME $FULL_IMAGE_NAME_DEV
+    podman push $FULL_IMAGE_NAME_DEV

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Podman `v5.y.z` downloads `v5.y` of the WSL OS image from the **latest** release
 
 That means that every GitHub release needs to include WSL disk images for old and new versions of Podman 5.
 
+## When a new dev version of Podman is bumped on main branch
+
+Before bumping the version of Podman in c/podman, the corresponding WSL image should be pushed to quay.io:
+
+```diff
+-    IMAGE_TAG_DEV: "5.4"
++    IMAGE_TAG_DEV: "5.5"
+```
+
 ## When a new version of Podman is released
 
 After a new version of Podman has been released (i.e. when the fedora package has been updated), the OCI artifact tags should be updated using development Podman version:
@@ -54,3 +63,5 @@ After a new version of Podman has been released (i.e. when the fedora package ha
 +    IMAGE_TAG_LATEST: "5.4"
 +    IMAGE_TAG_NEXT: "5.5"
 ```
+
+Note that at that point `IMAGE_TAG_NEXT` and `IMAGE_TAG_DEV` will match.


### PR DESCRIPTION
Before bumping the version on c/podman to 5.5, we need the corresponding WSL image to be pushed to quay.io.
Since v5.4.0 hasn't been released yet, we continue pushing both tags 5.4 and 5.3, too (the three images all have the same content).