### PR TITLE
Upgrade fedora version to 41

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 env:
-  IMAGE_TAG: 40
+  IMAGE_TAG: 41
   GITHUB_SERVER_URL: "https://github.com"
   CIRRUS_SHELL: bash
   IMAGE_SUFFIX: "c20240821t171500z-f40f39d13"


### PR DESCRIPTION
Update the tag of the image docker.io/library/fedora that is used as the base for the WSL image.

I am opening this as a draft to get some initial feedback on the update from Fedora 40 to 41, but I will have to locally build and test it before considering merging it. Fedora 40 EOL is 2025-05-28.