### PR TITLE
Stop updating 5.3 image on quay.io

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,12 @@
 env:
-  IMAGE_TAG: 40 
+  IMAGE_TAG: 40
   GITHUB_SERVER_URL: "https://github.com"
   CIRRUS_SHELL: bash
   IMAGE_SUFFIX: "c20240821t171500z-f40f39d13"
   FEDORA_AARCH64_AMI: "fedora-podman-aws-arm64-${IMAGE_SUFFIX}"
   FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"
   PCURL_RETRY: "curl --retry 5 --retry-delay 8 --retry-all-errors -L"
-  PACKAGE_LIST: "procps-ng openssh-server net-tools iproute dhcp-client crun-wasm wasmedge-rt qemu-user-static subscription-manager gvisor-tap-vsock-gvforwarder cifs-utils nfs-utils-coreos ansible-core" 
+  PACKAGE_LIST: "procps-ng openssh-server net-tools iproute dhcp-client crun-wasm wasmedge-rt qemu-user-static subscription-manager gvisor-tap-vsock-gvforwarder cifs-utils nfs-utils-coreos ansible-core"
   VER_PFX: "5.0"
 
 aws_credentials: ENCRYPTED[d8df25d9f680ea7b046e9883851355574913eb4bf7b89acc4efe8e039a4fc0112ade4469ff98d6a9a22285d495034905]
@@ -122,8 +122,8 @@ release_task:
     IMAGE_REGISTRY: "quay.io"
     IMAGE_REPO: "podman"
     IMAGE_NAME: "machine-os-wsl"
-    IMAGE_TAG_LATEST: "5.3"
-    IMAGE_TAG_NEXT: "5.4"
+    IMAGE_TAG_LATEST: "5.4"
+    IMAGE_TAG_NEXT: "5.5"
     IMAGE_TAG_DEV: "5.5"
   depends_on:
     - build
@@ -142,7 +142,7 @@ release_task:
     for arch in amd64 arm64; do
       echo "Fetching build upload for $arch"
       CACHE_URL="http://$CIRRUS_HTTP_CACHE_HOST/upload-$VER_PFX-$CIRRUS_BUILD_ID-$arch"
-      curl -L -f -o upload-$VER_PFX-$arch.tar $CACHE_URL || test "$?" == "22" 
+      curl -L -f -o upload-$VER_PFX-$arch.tar $CACHE_URL || test "$?" == "22"
       echo    "$VER_PFX - $arch" >> ./changes
       echo -e "==============\n" >> ./changes
       if [ ! -f ./upload-$VER_PFX-$arch.tar ]; then
@@ -157,7 +157,7 @@ release_task:
       fi
     done
 
-    if [ -z "$SHOULD_RELEASE" ]; then 
+    if [ -z "$SHOULD_RELEASE" ]; then
       echo "All builds were skipped, Nothing to release."
       exit
     fi
@@ -174,7 +174,7 @@ release_task:
       cp $VER_PFX-latest-$arch 5.2-latest-$arch
       cp $VER_PFX-latest-$arch 5.3-latest-$arch
     done
-    
+
     STAMP=`date -u '+%Y%m%d%H%M%S'`
     NEXT_RELEASE="v${STAMP}"
     echo $NEXT_RELEASE > version


### PR DESCRIPTION
v5.3.x of Podman remote is not getting bug fixes anymore and will become incompatible with newer versions of the WSL image (e.g. when switching to fedora 41).

We need to stop updating the 5.3 tag of the WSL image.