### PR TITLE
Stop doing GH releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,7 +116,6 @@ release_task:
   only_if: $CIRRUS_BRANCH == 'main' && $CIRRUS_PR == "" && $CIRRUS_TAG == ""
   execution_lock: podman-wsl-fedora-5-release
   env:
-    GH_TOKEN: ENCRYPTED[8297ab7a306113a13517c34bfa60293c25b6f07ea8e0518eb0dbf13f6a4e94705fb875e6957558076d8ffcc73821f464]
     QUAY_PODMAN_USERNAME: ENCRYPTED[61302bbc5de3e9a51dde72807c2d6c4e5834aab5f9e00db61c1e8b43a83d08e4dfdc61ca81eb6af0d60739f378be647a]
     QUAY_PODMAN_PASSWORD: ENCRYPTED[55580283bbbf7d9b5fca46bef2deef30b10d9191981965addc2ab5d48ef3515740e464a82caf416d2fba4aa47233d855]
     IMAGE_REGISTRY: "quay.io"
@@ -133,9 +132,7 @@ release_task:
     region: us-east-1
     architecture: amd64
   setup_script: |
-    dnf install 'dnf-command(config-manager)'
-    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-    dnf install -y gh git
+    dnf install -y git
   release_script: |
     set +o verbose
     HTTP_PREFIX="$GITHUB_SERVER_URL/$CIRRUS_REPO_FULL_NAME/releases/latest/download"
@@ -164,26 +161,6 @@ release_task:
     test -z "$FETCH1" || echo "Fetching past artifacts for skipped builds "
     test -z "$FETCH1" || $PCURL_RETRY -LO "$FETCH1"
     test -z "$FETCH2" || $PCURL_RETRY -LO "$FETCH2"
-
-    # temporary 5.1, 5.2 and 5.3 clone until divergance occurs
-    for arch in amd64 arm64; do
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.1-rootfs-$arch.tar.zst
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.2-rootfs-$arch.tar.zst
-      cp $VER_PFX-rootfs-$arch.tar.zst 5.3-rootfs-$arch.tar.zst
-      cp $VER_PFX-latest-$arch 5.1-latest-$arch
-      cp $VER_PFX-latest-$arch 5.2-latest-$arch
-      cp $VER_PFX-latest-$arch 5.3-latest-$arch
-    done
-
-    STAMP=`date -u '+%Y%m%d%H%M%S'`
-    NEXT_RELEASE="v${STAMP}"
-    echo $NEXT_RELEASE > version
-    echo "Releasing $NEXT_RELEASE"
-    sha256sum *rootfs*.tar.zst > shasums
-    set -o verbose
-    gh release create $NEXT_RELEASE -t $NEXT_RELEASE -d -F changes
-    gh release upload $NEXT_RELEASE *latest* *rootfs*.tar.zst shasums version
-    gh release edit $NEXT_RELEASE --draft=false
 
     # Package the WSL zst compressed disks as an OCI artifact
     FULL_IMAGE_NAME=$IMAGE_REGISTRY/$IMAGE_REPO/$IMAGE_NAME:$IMAGE_TAG_LATEST

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The image is distributed as a [zstd compressed](https://facebook.github.io/zstd/
 The CI is triggered every 3 hours **and** at every push to the main branch.
 
 At every update of the disk image:
-- a new [GitHub release](https://github.com/containers/podman-machine-wsl-os/releases) is created and the new zstd-compressed disk images is added.
 - a new OCI artifact is pushed to [quay.io/podman/machine-os-wsl](https://quay.io/repository/podman/machine-os-wsl?tab=tags)
 
 ## Build Process Details
@@ -37,12 +36,6 @@ WSL disk images build is disconnected to Podman release process.
 The WSL disk image build is triggered every 3 hours and it looks for a new version of Podman. But it looks for an update on Fedora stable and that's usually updated a few days after a Podman release.
 
 For example [Podman v5.2.2 has been released on the 2024-08-21](https://github.com/containers/podman/releases/tag/v5.2.2) but [has been included in Fedora 40 stable](https://bodhi.fedoraproject.org/updates/FEDORA-2024-435a743cf7) one week after that, and the updated WSL disk image [has been released on the 2024-08-27](https://github.com/containers/podman-machine-wsl-os/releases/tag/v20240827181401).
-
-## Always publish current and old version of the disk on GitHub 
-
-Podman `v5.y.z` downloads `v5.y` of the WSL OS image from the **latest** release on this GitHub repository. For example Podman `v5.1.2` downloads the file `5.1-rootfs-amd64.tar.zst` (or the arm64 equivalent) from the latest release.
-
-That means that every GitHub release needs to include WSL disk images for old and new versions of Podman 5.
 
 ## When a new dev version of Podman is bumped on main branch
 


### PR DESCRIPTION
Since Podman v5.3 the WSL image is pulled from quay.io. Older versions are pulling the image gz from the latest GH release, but the current version is incompatible with the newest images.
c.f. https://github.com/containers/podman-machine-wsl-os/issues/15

Once this PR gets merged, we should delete the releases that have been published after [that PR](https://github.com/containers/podman-machine-wsl-os/pull/13).