### PR TITLE
Bump dev image to v5.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,7 +123,7 @@ release_task:
     IMAGE_NAME: "machine-os-wsl"
     IMAGE_TAG_LATEST: "5.4"
     IMAGE_TAG_NEXT: "5.5"
-    IMAGE_TAG_DEV: "5.5"
+    IMAGE_TAG_DEV: "5.6"
   depends_on:
     - build
   ec2_instance:


### PR DESCRIPTION
Update `IMAGE_TAG_DEV` to 5.6.
After the release of 5.5 we will update `IMAGE_TAG_LATEST` and `IMAGE_TAG_NEXT` too.